### PR TITLE
Major changes to image file paths, migrate images to static/img, scri…

### DIFF
--- a/pyscripts/migrate.py
+++ b/pyscripts/migrate.py
@@ -1,0 +1,93 @@
+import shutil, os
+import sys
+import time
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+import re
+import platform
+from functools import reduce
+
+
+POST_ROOT = fr"E:\01_Dev\11ty\dhananjayhegde\posts"
+IMAGE_DEST = fr"E:\01_Dev\11ty\dhananjayhegde\static\img"
+
+ident_level = 0
+
+def add_ident():
+    global ident_level
+    ident_level += 1
+
+def reduce_ident():
+    global ident_level
+    ident_level -= 1
+
+def replace_image_path_in_posts(post_file, year, month):
+    # prefix all image paths with /static/img/<yyyy>/<mm>/
+    add_ident()
+    print(tabs( ident_level ) + "--> Replacing image paths in post content")
+    with open(post_file, "r", encoding="utf-8") as f:
+        content = f.read()
+    
+    if not content:
+        print(tabs( ident_level ) + "Could not read post content: {post_file}")
+    
+    new_content = content
+    
+    # Replace image paths in post body
+    image_names = [x for x in re.findall(r".*/(.*.png)", content)]    
+    for image in image_names:
+        new_content = re.sub(fr"!\[.*\]\(images/{image}\)", f"![{image}](/static/img/{year}/{month}/{image})", new_content)
+    
+    with open(post_file, "w", encoding="utf-8") as f:
+        f.write(new_content)
+        print(tabs( ident_level ) + "<-- Done replacing, exiting")
+
+    reduce_ident()
+
+
+def copy_images(source_dir, dest_dir):
+    add_ident()
+    print(tabs( ident_level ) + "--> Copying images to /static/img/")
+    for folder_name, subfolders, filenames in os.walk(source_dir):
+        for filename in filenames:
+            image_dest_file = f"{dest_dir}\\{filename}"
+            image_source_file = f"{source_dir}\\{filename}"
+
+            add_ident()
+            print(tabs( ident_level ) + f"Source: {image_source_file}")
+            print(tabs( ident_level ) + f"Destination {image_dest_file}")            
+            reduce_ident()
+            
+            try:
+                os.makedirs(os.path.dirname(image_dest_file), exist_ok=True)
+                shutil.copy(image_source_file, image_dest_file)
+            except OSError as e:
+                print(tabs( ident_level ) + f"MAKEDIRS error: {image_dest_file}")
+                print(e)
+                print(tabs( ident_level ) + "<-- Errored, exiting without copying")
+    
+    print(tabs( ident_level ) + "<-- Done copying, exiting")
+    reduce_ident()
+
+def tabs(level):
+    return "\t" * level
+
+def main(source, dest):    
+    for folder_name, subfolders, filenames in os.walk(source):
+        for filename in filenames:
+            if re.search(".*\.md", filename):
+                post_path = f"{folder_name}\{filename}"
+                print(tabs( ident_level ) + f"\n--> Migrating images for: {post_path}")
+                matches = re.search(r".*(\d{4}).*(\d{2}).*", folder_name)
+                year = matches.group(1)
+                month = matches.group(2)
+                
+                image_source_dir = fr"{folder_name}\images"
+                image_dest_dir = fr"{IMAGE_DEST}\{year}\{month}"
+
+                copy_images(image_source_dir, image_dest_dir)
+                replace_image_path_in_posts(post_path, year, month)
+                print(tabs( ident_level ) + "<-- Done, migrating images")
+                
+
+main(POST_ROOT, IMAGE_DEST)

--- a/pyscripts/newpost.py
+++ b/pyscripts/newpost.py
@@ -1,0 +1,177 @@
+import shutil, os
+import sys
+import time
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+import re
+import platform
+from functools import reduce
+
+DRAFT_SOURCE = r'E:\02_Docs\Obsidian\DhananjayHegde\Blog\Draft'
+dest_root = r'E:\01_Dev\11ty\dhananjayhegde\posts'
+IMAGE_DEST_ROOT = r'E:\01_Dev\11ty\dhananjayhegde\static\img'
+IMAGE_SOURCE = r'E:\02_Docs\Obsidian\DhananjayHegde'
+dest_published = r'E:\02_Docs\Obsidian\DhananjayHegde\Blog\Published'
+
+def get_create_modified_date(file_path):    
+    """
+    Try to get the date that a file was created, falling back to when it was
+    last modified if that isn't possible.
+    See http://stackoverflow.com/a/39501288/1709587 for explanation.
+    """
+    if platform.system() == 'Windows':
+        return os.path.getctime(file_path)
+    else:
+        stat = os.stat(file_path)
+        try:
+            return stat.st_birthtime
+        except AttributeError:
+            # We're probably on Linux. No easy way to get creation dates here,
+            # so we'll settle for when its content was last modified.
+            return stat.st_mtime
+
+def make_front_matter(file_content="", title="", file_date=None):
+    if not file_date:
+        return
+
+    """
+    Sample Obsidian Front Matter:
+    ---
+    excerpt: Learn the basics of software architecture, different aspects of it and what it entails to be an architect
+    categories: software-architecture, sap
+    hashtags: architecture, availability, foundation, software, testability
+    ---
+    """
+    orig_fm_list = [x for x in filter(lambda t: t, [t for t in file_content.split("---")[1].split("\n")])]
+    # fm => key:value
+    fm_dict = dict([ tuple( s for s in fm.split(":") ) for fm in orig_fm_list])
+    category_string = reduce(lambda x,y: x + "\n  - " + y, fm_dict.get('categories', "").split(","))
+    tag_string = reduce(lambda x,y: x + "\n  - " + y, fm_dict.get('hashtags', "").split(","))
+    
+    eleventy_front_matter = f"""--- \ntitle: {title} \ndate: {file_date.strftime("%Y-%m-%d")} \ncategories:\n  - {category_string}\ntags:\n  - {tag_string}\nexcerpt: {fm_dict['excerpt']} \n---\n"""
+    return { 'eleventy': eleventy_front_matter, }
+
+def add_front_matter_to_content(file_content="", eleventy_front_matter=""):
+    if not file_content or not eleventy_front_matter:
+        return
+
+    """
+    ---
+    front matter....
+    ---
+    content...
+    """
+    orig_content_wo_fm = "---".join(file_content.split("---")[2:])
+    return eleventy_front_matter + "\n" + orig_content_wo_fm
+
+def copy_file_to_dest(source_path="", dest_file_name="", dest_root="", modif_date=None, content=""):
+    """
+    copy file to a folder under /posts like this
+    posts/year/month/file_name.md
+    """
+    if not content or not source_path or not dest_file_name or not dest_root:
+        {'source':"", 'destination': ""}
+        return
+    
+    year = modif_date.strftime("%Y")
+    month = modif_date.strftime("%m")
+
+    dest_path = f'{dest_root}\{year}\{month}\{dest_file_name}'
+    os.makedirs(os.path.dirname(dest_path), exist_ok=True)
+    
+    with open(dest_path, "w") as f:
+        f.write(content)
+    
+    return {'source': source_path, 'destination': dest_path}
+
+def move_to_published(source_path):
+    shutil.move(source_path, dest_published)
+
+def prefix_substring(text, substring, prefix):
+    """Prefixes a substring with a given string."""
+
+    if substring in text:
+        return text.replace(substring, prefix + substring)
+    else:
+        return text
+
+def copy_images(image_names, images_dest_root, image_source_root, modif_date):    
+    year = modif_date.strftime("%Y")
+    month = modif_date.strftime("%m")
+
+    image_dest_dir = fr"{images_dest_root}\{year}\{month}"
+
+    for image_name in image_names:
+        for orig_image, new_image in image_name.items():
+            image_dest_file = f"{image_dest_dir}\\{new_image}"
+            image_source_file = f"{image_source_root}\\{orig_image}"
+
+            print(image_dest_file)
+            print(image_source_file)
+
+            try:
+                os.makedirs(os.path.dirname(image_dest_file), exist_ok=True)
+                shutil.copy(image_source_file, image_dest_file)
+            except OSError as e:
+                print("MAKEDIRS error")
+                print(e)
+
+def extract_and_replace_image_names(content, modif_date):
+    year = modif_date.strftime("%Y")
+    month = modif_date.strftime("%m")
+    special_chars = r'[^a-zA-Z0-9\.]'
+    
+    # image_names = re.findall(r"Pasted image \d+.png", content)
+    # new_content = re.sub(r"(?P<original>Pasted image \d+.png)", f"/{year}/{month}/\g<original>", content)
+    
+    image_names = [{x: re.sub(special_chars, "-", x).lower()} for x in re.findall(r"Pasted image \d+.png", content)]
+
+    print(str(image_names))
+
+    new_content = content
+
+    for image in image_names:
+        for key, value in image.items():
+            new_content = new_content.replace(f"![[{key}]]", f"![{key}](/static/img/{year}/{month}/{value})")
+
+    return { 'image_names' : image_names, 'content': new_content }
+    
+
+def main(source, dest):
+    file_found = False
+    special_chars = r'[^a-zA-Z0-9\.]'
+    
+    for folderName, subfolders, filenames in os.walk(source):
+        for filename in filenames:
+            if re.search(".*\.md", filename):
+                print(f'---------------------\n{filename}')
+                
+                # original file path
+                original_file_path = folderName + "\\" + filename
+                # original file content
+                file_content = open(original_file_path).read()
+                # file creation/modified date time
+                modif_date_time = get_create_modified_date(original_file_path)
+                modif_date = datetime.fromtimestamp(modif_date_time, timezone(offset=timedelta(hours=5.5)))
+                
+                # Eleventy Front Matter
+                fm_11ty_dict = make_front_matter(file_content, filename.split(".md")[0], modif_date)
+                content_w_11ty_fm = add_front_matter_to_content(file_content, fm_11ty_dict.get('eleventy', ""))
+                
+                # Replace image file names with new path name
+                enriched_content = extract_and_replace_image_names(content_w_11ty_fm, modif_date)
+                
+                # Copy markdown file to 11ty/dhananjayhegde/posts/ directory
+                new_file_name = re.sub(special_chars, "-", filename.lower())
+                result = copy_file_to_dest(original_file_path, new_file_name, dest_root, modif_date, enriched_content['content'])
+
+                # copy images to 11ty/dhananjayhegde/static/img/<yyyy>/<mm>/
+                copy_images(enriched_content['image_names'], IMAGE_DEST_ROOT, IMAGE_SOURCE, modif_date)
+
+                # Move original markdown to Published/ folder
+                move_to_published(original_file_path)
+
+                print(f"\tCopied to {result['destination']}")
+                print(f"\tMoved to {dest_published}")
+
+main(DRAFT_SOURCE, dest_root)


### PR DESCRIPTION
- Major changes to image file paths
- migrate images to static/img
- scripts to publish posts from Obsidian folder to 11ty/posts folder
- scripts to migrate images from respective posts/ folder to static/img
- one time execution migrate.py to migrate all images and update image path on all existing posts